### PR TITLE
feat: toggle to hide answers

### DIFF
--- a/content/en/locale.json
+++ b/content/en/locale.json
@@ -19,5 +19,7 @@
   "continue": "continue",
   "incorrect": "❌ Not quite. Correct answer: ",
   "correct": "✅ Correct! Well done!",
-  "done": "🎉 All exercises completed!"
+  "done": "🎉 All exercises completed!",
+
+  "reveal": "Click to Reveal"
 }

--- a/public/settings.js
+++ b/public/settings.js
@@ -21,10 +21,34 @@ if (theme === "light") {
 
 window.localStorage.setItem("theme", theme);
 
-const handleToggleClick = () => {
+const handleThemeToggleClick = () => {
   const element = document.documentElement;
   element.classList.toggle("dark");
 
   const isDark = element.classList.contains("dark");
   localStorage.setItem("theme", isDark ? "dark" : "light");
+};
+
+const shouldHideAnswers = (() => {
+  const localStorageTheme = localStorage?.getItem("hide-answers") ?? "";
+  if (["yes", "no"].includes(localStorageTheme)) {
+    return localStorageTheme;
+  }
+  return "no";
+})();
+
+if (shouldHideAnswers === "no") {
+  document.documentElement.classList.remove("hide-answers");
+} else {
+  document.documentElement.classList.add("hide-answers");
+}
+
+window.localStorage.setItem("hide-answers", shouldHideAnswers);
+
+const handleHideAnswersToggleClick = () => {
+  const element = document.documentElement;
+  element.classList.toggle("hide-answers");
+
+  const shouldHideAnswers = element.classList.contains("hide-answers") ? "yes" : "no";
+  localStorage.setItem("hide-answers", shouldHideAnswers);
 };

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -60,7 +60,7 @@ const { title, description, image = "/logo.png" } = Astro.props;
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={socialImageURL} />
 
-<script is:inline src="/light-mode.js"></script>
+<script is:inline src="/settings.js"></script>
 <!-- Analytics -->
 <script
   data-goatcounter={`https://${GOATCOUNTER_URL}/count`}

--- a/src/components/DarkModeToggle.astro
+++ b/src/components/DarkModeToggle.astro
@@ -1,4 +1,4 @@
-<button id="themeToggle">
+<button id="themeToggle" title="Toggle Dark Mode">
   <svg
     width="30px"
     xmlns="http://www.w3.org/2000/svg"
@@ -25,7 +25,7 @@
     cursor: pointer;
     position: absolute;
     top: 0;
-    right: 0;
+    right: 40px;
   }
   .sun {
     fill: var(--grey);
@@ -58,5 +58,5 @@
 <script>
   document
     .getElementById("themeToggle")
-    ?.addEventListener("click", handleToggleClick);
+    ?.addEventListener("click", handleThemeToggleClick);
 </script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import DarkModeToggle from "@/components/DarkModeToggle.astro";
+import HideAnswersToggle from "./HideAnswersToggle.astro";
 ---
 
 <style>
@@ -37,4 +38,5 @@ import DarkModeToggle from "@/components/DarkModeToggle.astro";
     <img alt="Wasona" src="/header.svg" />
   </a>
   <DarkModeToggle />
+  <HideAnswersToggle />
 </header>

--- a/src/components/HideAnswersToggle.astro
+++ b/src/components/HideAnswersToggle.astro
@@ -1,0 +1,62 @@
+<button id="hideAnswersToggle" title="Hide/Show Answers">
+  <svg
+    width="30px"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    aria-label="hide/show answers switch"
+  >
+    <path
+      class="hide"
+      fill-rule="evenodd"
+      d="M12 1.818a.8.8 0 0 0-.8.801v2.5a.8.8 0 0 0 1.6 0v-2.5a.8.8 0 0 0-.8-.8zM6.668 2.836a.8.8 0 0 0-.3.082.8.8 0 0 0-.36 1.072l1.117 2.24a.8.8 0 0 0 1.432-.715L7.44 3.277a.8.8 0 0 0-.773-.441zm10.65 0a.8.8 0 0 0-.668.441l-1.115 2.237a.8.8 0 0 0 1.432.715l1.115-2.239a.8.8 0 0 0-.36-1.072.8.8 0 0 0-.404-.082zM2.752 5.716a.8.8 0 0 0-.566.235.8.8 0 0 0 0 1.131L3.953 8.85a.8.8 0 0 0 1.131-1.131L3.316 5.95a.8.8 0 0 0-.564-.234zm18.588 0a.8.8 0 0 0-.567.235L19.006 7.72a.8.8 0 0 0 1.133 1.13l1.767-1.767a.8.8 0 0 0 0-1.13.8.8 0 0 0-.566-.235zM12 7.3c-4.351 0-7.553 4.267-7.553 4.267a.704.704 0 0 0 0 .87S7.65 16.703 12 16.703s7.553-4.267 7.553-4.267a.704.704 0 0 0 0-.87S16.35 7.3 12 7.3zm0 1.408c2.986 0 5.392 2.615 5.99 3.293-.597.677-3.003 3.295-5.99 3.295S6.607 12.677 6.01 12c.598-.678 3.004-3.293 5.99-3.293z"
+    ></path>
+    <path
+      class="show"
+      fill-rule="evenodd"
+      d="M4.994 11.297a.704.704 0 0 0-.428.15.704.704 0 0 0-.119.989S7.65 16.703 12 16.703s7.553-4.267 7.553-4.267a.704.704 0 0 0-.12-.989.704.704 0 0 0-.519-.144.704.704 0 0 0-.469.263S15.38 15.295 12 15.295c-3.38 0-6.445-3.729-6.445-3.729a.704.704 0 0 0-.56-.27zm-.447 3.623a.8.8 0 0 0-.594.232l-1.767 1.77a.8.8 0 0 0 0 1.13.8.8 0 0 0 1.13 0l1.768-1.767a.8.8 0 0 0-.537-1.365zm14.998 0a.8.8 0 0 0-.54 1.365l1.768 1.768a.8.8 0 0 0 1.133 0 .8.8 0 0 0 0-1.131l-1.767-1.77a.8.8 0 0 0-.594-.232zM7.828 17.332a.8.8 0 0 0-.703.443l-1.117 2.237a.8.8 0 0 0 .36 1.072.8.8 0 0 0 1.073-.357l1.116-2.239a.8.8 0 0 0-.729-1.156zm8.436 0a.8.8 0 0 0-.729 1.156l1.115 2.239a.8.8 0 0 0 1.073.357.8.8 0 0 0 .359-1.072l-1.115-2.237a.8.8 0 0 0-.703-.443zm-4.319.754a.8.8 0 0 0-.746.799v2.5a.8.8 0 0 0 .801.799.8.8 0 0 0 .8-.8v-2.5a.8.8 0 0 0-.855-.798z"
+    ></path>
+  </svg>
+</button>
+
+<style>
+  #hideAnswersToggle {
+    border: 0;
+    background: none;
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+  .hide {
+    fill: var(--grey);
+  }
+
+  #hideAnswersToggle:hover .hide {
+    fill: var(--accent);
+  }
+
+  .show {
+    fill: transparent;
+  }
+
+  :global(.hide-answers) .hide {
+    fill: transparent;
+  }
+
+  :global(.hide-answers) #hideAnswersToggle:hover .hide {
+    fill: transparent;
+  }
+
+  :global(.hide-answers) .show {
+    fill: var(--grey);
+  }
+
+  :global(.hide-answers) #hideAnswersToggle:hover .show {
+    fill: var(--accent);
+  }
+</style>
+<script>
+  document
+    .getElementById("hideAnswersToggle")
+    ?.addEventListener("click", handleHideAnswersToggleClick);
+</script>

--- a/src/components/Sentence.astro
+++ b/src/components/Sentence.astro
@@ -1,4 +1,5 @@
 ---
+import { locales } from "@/utils/i18n";
 import { encode } from "@/utils/ucsur";
 interface Props {
   // sitelen pona
@@ -7,12 +8,11 @@ interface Props {
   sl: string;
   // translation
   m: string;
-  // spoiler shield for practice
-  hide?: "sp" | "sl" | "m";
 }
-const onclick = "this.classList.toggle('revealed')";
-const { sp, sl, m, hide } = Astro.props;
+const { sp, sl, m } = Astro.props;
 const sp_ = sp || encode(sl);
+const lang = Astro.url.pathname.split("/")[1] ?? "en";
+const locale = locales[lang];
 ---
 
 <style>
@@ -28,5 +28,5 @@ const sp_ = sp || encode(sl);
   <br />
   <span dir="ltr" class="sl" set:html={sl} />
   <br />
-  <span set:html={m} />
+  <span class="maybe-hide" onclick="this.classList.toggle('maybe-hide')" data-tooltip={locale["reveal"]} set:html={m} />
 </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -125,6 +125,21 @@ hr {
 .sl {
     font-style: italic;
 }
+
+.hide-answers .maybe-hide::before {
+    content: attr(data-tooltip);
+    color: var(--txt);
+    position: absolute;
+}
+
+.hide-answers .maybe-hide {
+    cursor: pointer;
+    color: var(--bg-3);
+    background-color: var(--bg-3);
+    margin-left: -3px;
+    padding-left: 3px;
+}
+
 /*
 Section dedicated to the React widget;
 I don't like React's native CSS handling


### PR DESCRIPTION
Answers are visible by default, can be hidden with a new toggle next to the theme toggle.
I created the Hide/show toggle icons myself and dedicate them to the public domain.
The "Click to Reveal" text is currently missing from every non-english `locale.json`.
<img width="260" height="478" alt="image" src="https://github.com/user-attachments/assets/9327b07b-61c5-4f58-bfa3-30f8848a8106" />

This is something I desperately wanted when learning.