### PR TITLE
de: remove unnecessary h2 to match en

### DIFF
--- a/content/de/basics-1/01-pronunciation.mdx
+++ b/content/de/basics-1/01-pronunciation.mdx
@@ -8,8 +8,6 @@ import PhonoTable from "@/components/PhonoTable.astro";
 import PhonoExamples from "../PhonoExamples.astro";
 import Audio from "@/components/Audio.astro";
 
-## Aussprache
-
 Toki Pona hat nur 9 Konsonanten und 5 Vokale. Klicke jeden an, um herauszufinden, wie er klingt!
 
 <PhonoTable />

--- a/content/de/basics-1/02-writing.mdx
+++ b/content/de/basics-1/02-writing.mdx
@@ -7,8 +7,6 @@ description: "Lerne, die Sitelen-Pona-Schrift zu lesen!"
 import Tabbed from "@/components/Tabbed.astro";
 import Row from "@/components/Row.astro";
 
-## Zwei Schriftsysteme
-
 Du hast schon gesehen, dass Toki Pona das lateinische Alphabet nutzt, das wir *sitelen Lasina* nennen. Aber viele von uns nutzen auch unser eigenes besonderes System namens *sitelen pona*, was *gutes Schreiben* bedeutet. Es ist eine Logographie: Jedes Wort auf Toki Pona bekommt ein eigenes kleines Zeichen. Es macht viel Spaß zu benutzen, und hilft dir dabei, dir Wörter zu merken!
 
 Schauen wir uns ein kurzes Gedicht an und vergleichen wir *sitelen Lasina* mit *sitelen pona*:

--- a/content/de/basics-1/03-simple-sentences.mdx
+++ b/content/de/basics-1/03-simple-sentences.mdx
@@ -47,8 +47,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Einfache Sätze
-
 Jetzt, wo du weißt, wie man Toki Pona liest, ist es Zeit, Wörter und Sätze zu lernen!  
 Hier sind ein paar Wörter für Dinge:
 

--- a/content/de/basics-1/04-adjectives.mdx
+++ b/content/de/basics-1/04-adjectives.mdx
@@ -44,8 +44,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Beschreiben!
-
 Jetzt kennst du ein paar Nomen (Dinge) und Verben (Aktionen). Fügen wir noch Adjektive (Beschreibungen) hinzu!  
 Merke dir ein paar Adjektive:
 

--- a/content/de/basics-1/05-parts-of-speech.mdx
+++ b/content/de/basics-1/05-parts-of-speech.mdx
@@ -32,8 +32,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Wortarten
-
 Manche von euch haben vielleicht bemerkt, dass ich das Wort **󱥡 sona** zweimal eingeführt habe, zuerst als Verb 'wissen', dann als Adjektiv 'weise'. Was ist es jetzt? Und woher weiß man das?
 
 In Wahrheit kann es beides sein! Wenn es nach einem Nomen steht, dann ist es ein Adjektiv. Wenn **󱤧 li** es als Prädikat einführt, dann ist es ein Verb. Es geht um die Stellung der Worte in einem Satz!

--- a/content/de/basics-1/06-pronouns.mdx
+++ b/content/de/basics-1/06-pronouns.mdx
@@ -77,8 +77,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Pronomen
-
 Du bist vermutlich langsam ermüdet von langen Sätzen und Wortarten. Drehen wir eine Stufe runter und zeigen wir auf Dinge.
 
 <List>

--- a/content/de/basics-1/07-names.mdx
+++ b/content/de/basics-1/07-names.mdx
@@ -76,11 +76,7 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Namen
-
 Auf Dinge zu zeigen ist schön, aber manchmal kann es auch schön sein, etwas genauer zu sein. Ich präsentiere: Namen! Eine revolutionäre Technologie, die es ermöglicht, über etwas Genaues zu reden.
-
-Lernen wir die Wörter für Dinge, die oft Namen haben:
 
 <List>
   <Word sl="nimi" m="Name, Wort" />

--- a/content/de/basics-1/08-prepositions.mdx
+++ b/content/de/basics-1/08-prepositions.mdx
@@ -84,8 +84,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Präpositionen
-
 Jetzt, wo wir ein paar Länder kennen, können wir über das Reisen reden! Aber wie sagt man, dass man irgendwohin geht oder von irgendwoher kommt? Dafür brauchen wir ein paar Verben:
 
 <List>

--- a/content/de/basics-1/09-activities.mdx
+++ b/content/de/basics-1/09-activities.mdx
@@ -75,8 +75,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Aktivitäten
-
 Lernen wir ein paar mehr Wörter für Dinge, die man tun kann!
 
 <List>

--- a/content/de/basics-1/10-story.mdx
+++ b/content/de/basics-1/10-story.mdx
@@ -60,8 +60,6 @@ Nachdem du fertig gehört hast, versuche, den Text laut vorzulesen. Schaue, ob d
   <Row sl="ni li pona tawa ona." m="Das hat seinen Hunger gesättigt." />
 </Tabbed>
 
-{/* Vielleicht hast du bemerkt, dass die Übersetzung nicht so wörtlich wie die Beispielsätze sind! Das passiert oft. Wenn du eine Geschichte hast, die über mehrere Sätze geht, fangen sie an, sich einander zu unterstützen. */}
-
 Hat irgendeiner der Sätze oder Übersetzungen dich stutzig gemacht? Vielleicht verstehst du sie noch nicht ganz? Gut! Das ist auch Teil vom Lernen. Jetzt kommt die Community ins Spiel. Trete einer aktiven Toki-Pona-Gruppe bei, zeige ihnen die Sätze, und frag nach Hilfe. Es gibt immer Leute, die sehr gerne helfen!
 
 * [kama sona](https://discord.gg/ChC6qtVsSE) ist ein Discord-Server, der für neue Lerner geeignet ist.

--- a/content/de/basics-2/11-home.mdx
+++ b/content/de/basics-2/11-home.mdx
@@ -79,8 +79,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Zuhause
-
 Zuhause haben wir viele Dinge:
 
 <List>

--- a/content/de/basics-2/12-requests.mdx
+++ b/content/de/basics-2/12-requests.mdx
@@ -50,8 +50,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Um etwas bitten
-
 Auf Toki Pona ist ein Satz mit **󱤧 li** ein Fakt. Manchmal wollen wir aber nicht über Fakten reden, sondern um etwas bitten. So sagen wir anderen Leuten, was wir wollen, das passiert. Wenn wir um etwas bitten, nutzen wir statt **󱤧 li** das Wort **󱥄 o**:
 
 <List>

--- a/content/de/basics-2/14-negation.mdx
+++ b/content/de/basics-2/14-negation.mdx
@@ -59,8 +59,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Verneinung
-
 Wir haben eben gelernt, wie man jemanden darum bittet, etwas zu tun. Aber wie bitten wir jemanden, etwas *nicht* zu tun? Dafür müssen wir Verneinung lernen, mit **󱤂 ala**:
 
 <List>

--- a/content/de/basics-2/15-with-like.mdx
+++ b/content/de/basics-2/15-with-like.mdx
@@ -76,8 +76,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Mit und Wie
-
 In Lektion 8 haben wir drei Präpositionen gelernt: **󱥩 tawa**, **󱤬 lon**, **󱥧 tan**, bei denen es um Ort und Richtung geht. Tatsächlich hat Toki Pona noch zwei Präpositionen:
 
 <List>

--- a/content/de/basics-2/17-questions.mdx
+++ b/content/de/basics-2/17-questions.mdx
@@ -74,8 +74,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Fragen
-
 Es gibt normalerweise zwei Arten von Fragen:
 
 * *Ja/Nein-Fragen*. Das sind Fragen, die positiv oder negativ mit Ja oder Nein beantwortet werden können.

--- a/content/de/basics-3/25-numbers.mdx
+++ b/content/de/basics-3/25-numbers.mdx
@@ -60,6 +60,8 @@ Reden wir über Zahlen!
   <Word sl="kipisi" m="Stück, Teil, teilen" />
 </List>
 
+## Kardinalzahlen
+
 Toki Pona hat Wörter für 1, 2, 5, aber nicht 3 oder 4! Das ist aber nicht allzu seltsam. Du kannst dir **󱥳 wan**, **󱥮 tu**, **󱤭 luka** als Münzen vorstellen, die 1, 2, und 5 wert sind. Zählen wir von 1 bis 10:
 
 <List>

--- a/content/de/basics-3/25-numbers.mdx
+++ b/content/de/basics-3/25-numbers.mdx
@@ -49,6 +49,8 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
+## Kardinalzahlen
+
 Reden wir über Zahlen!
 
 <List>
@@ -59,8 +61,6 @@ Reden wir über Zahlen!
   <Word sl="ale" m="alles, jedes" />
   <Word sl="kipisi" m="Stück, Teil, teilen" />
 </List>
-
-## Kardinalzahlen
 
 Toki Pona hat Wörter für 1, 2, 5, aber nicht 3 oder 4! Das ist aber nicht allzu seltsam. Du kannst dir **󱥳 wan**, **󱥮 tu**, **󱤭 luka** als Münzen vorstellen, die 1, 2, und 5 wert sind. Zählen wir von 1 bis 10:
 

--- a/content/de/basics-3/25-numbers.mdx
+++ b/content/de/basics-3/25-numbers.mdx
@@ -49,8 +49,6 @@ import List from "@/components/List.astro";
 import Word from "@/components/Word.astro";
 import Practice from "@/components/Practice.astro";
 
-## Kardinalzahlen
-
 Reden wir über Zahlen!
 
 <List>


### PR DESCRIPTION
This ports the change from 97bf933 to the German translation.

(With this PR, the German translation is in line with the English course. Maintainers of other languages are encouraged to check that their translations are up-to-date, specifically matching these changes to the English version: 38c67ee 0c69c59 97bf933. [Discussion on Discord](https://discord.com/channels/972470770443886662/1490648592640114750/1493273082801164442))